### PR TITLE
all files

### DIFF
--- a/py/README.md
+++ b/py/README.md
@@ -1,5 +1,20 @@
 # pysoymocha
+
 ### Bunch of tools to help with setup
+
+## SSH Keys
+
+If this is the first time you are setting up cloudlab, you will want to generate and upload your public key. Generate an ed25519 SSH key (w/o a passphrase) or these scripts will fail.
+
+```bash
+ssh-keygen -t ed25519 -C {name}
+```
+
+Run `cat ~/.ssh/id_ed25519.pub` and upload the output to cloudlab -> manage ssh keys so that you can do passwordless ssh authentication.
+
+## Virtual Env
+
+In root, `echo 'y' | conda create --name mocha` and then `conda activate mocha`. In the future, you can just source `env.sh`.
 
 ## Cloudlab
 
@@ -8,16 +23,18 @@ If this is the first time you are using the cloudlab experiment, you may want so
 ```bash
 python sminstaller.py --manifest manifest.xml --pvt-key ~/.ssh/id_ed25519 --session mocha
 ```
+
 Generate a TMUX script under `$PROJ_HOME/build`: `tmux.<session_name>.sh`.
 
 ```bash
 # Local
 python smtmuxgen.py --manifest manifest.xml --session mocha
-``` 
+```
 
-Run this script to build out a tmux session. Then attach the session to get started. This should have zsh installed on all nodes, so type in `zsh` if the logon doesn't directly launch the zsh prompt.
+Run this script to build out a tmux session. Then attach (tmux attach -t {session_name}) the session to get started. This should have zsh installed on all nodes, so type in `zsh` if the logon doesn't directly launch the zsh prompt.
 
 ## Lightning Network
+
 This requires some manual intervention. I'll try to fully automate the process soon.
 
 ### Getting the config files on Cloudlab nodes
@@ -30,6 +47,7 @@ python sminstaller.py --manifest manifest.xml --pvt-key ~/.ssh/id_ed25519 --sess
 ```
 
 The below will copy over `assets/lightning` to all remote nodes under the directory: `<session_name>/assets/lightning`.
+
 ```bash
 # Local
 python sminstaller.py --manifest manifest.xml --pvt-key ~/.ssh/id_ed25519 --session mocha --app lightning
@@ -38,6 +56,7 @@ python sminstaller.py --manifest manifest.xml --pvt-key ~/.ssh/id_ed25519 --sess
 ### Running BTC nodes (simnet) using BTCD
 
 On nodes that are going to run `btcd`, generate btc config. Let this node be `nodeX`.
+
 ```bash
 # Cloudlab Node
 source <session_name>/assets/lightning/btcconfgen.sh
@@ -51,9 +70,11 @@ Use the following to copy over RPC certificate and LND configuration to the othe
 
 ```bash
 # Local
-python smlightning.py --manifest ../manifest.xml --pvt-key ~/.ssh/id_ed25519 --session <session_name> --config "nodeX:*" 
+python smlightning.py --manifest manifest.xml --pvt-key ~/.ssh/id_ed25519 --session <session_name> --config "nodeX:*"
 ```
-The above will produce the `<session_name>/assets/lndconfgen_done.sh`. On the LND nodes: 
+
+The above will produce the `<session_name>/assets/lndconfgen_done.sh`. On the LND nodes:
+
 ```bash
 # Cloudlab Node
 source <session_name>/assets/lndconfgen_done.sh
@@ -70,7 +91,7 @@ lncli-ws create
 
 ### Funding Wallets
 
-To fund the wallet, we can use the BTC node(s) to mine and direct the funds to these wallets.
+To fund the wallet, we can use the BTC node(s) to mine and direct the funds to these wallets. `np2wkh` specifes the type of address and stands for Pay to Nested Witness Key Hash
 On the LND node, whose wallet we want to fund, generate a new address:
 
 ```bash
@@ -84,66 +105,69 @@ lncli-ws newaddress np2wkh
 ```
 
 On corresponding BTC node, stop `btcd`, and restart as follows:
+
 ```bash
 # Cloudlab Node
 btcd --miningaddr=<the address we got in previous step>
 ```
+
 On another terminal, on the same node:
+
 ```bash
 # Cloudlab Node
 btcctl generate 100
 ```
+
 This will generate 100 blocks and add the mined BTC to the specified wallet.
 
 Similarly fund other wallets on other nodes.
 
+To validate that you receieved the funding, you can use the `lncli-ws walletbalance` command, which will tell you your balance denominated in satoshis (1 bitcoin == 100 000 000 satoshi)
+
 ### Opening a channel
-There are 3 steps to this process. 
-1. We connect the nodes that we want a channel in between.
-2. We create a channel between these nodes which will remain pending till the commited transactions reach a specific depth. 
-3. We mine a few blocks so that the said depth is reached and the channel is confirmed.
 
-Initially these will return empty lists:
-```bash
-# Cloudlab LND Node
-lncli-ws listpeers
-lncli-ws pendingchannels
-lncli-ws listchannels
+Set up a `routing.yaml` file with the following format:
+
+```yaml
+Nodes:
+  node1:
+    name: Alice # specifies the name of the node, this is used for logging purposes.
+    address: [genereated with np2wkh]
+    identity_pubkey: [from getinfo]
+    ip: [use hostname -I]
+  ...
+  mining_node:
+    name: node0
+    blocks_to_generate: 6 # specifies the number of blocks to generate after the channel is opened.
+Channels:
+  channel1:
+    firstNode: node1 # use the tmux given name / the name of the object defined above
+    secondNode: node2
+    localAmt: 1000000 # specifies the amount of money that the calling node will commit to the channel.
+  ...
 ```
 
-Use `getinfo` to get public identity of a node:
+Now, locally run the following python script. If you already have channels defined from a routing file, you can disconnect them first.
+
 ```bash
-# On Cloudlab LND Node A 
-lncli-ws getinfo
-hostname -I
+# local
+python smchannels.py --manifest manifest.xml --pvt-key ~/.ssh/id_ed25519 --session mocha --config routing.yaml --disconnect
 ```
 
-Then use this address on another node to connect the two:
-```bash
-# On Cloudlab LND Node B
-lncli-ws connect <address_of_A>@<ip_of_A>
-```
-Now we should see something upon running this:
-```bash
-# Cloudlab Node A or B
-lncli-ws listpeers
-```
-Open a channel as follows:
-```bash
-lncli-ws openchannel --node_key=<address_of_A> --local_amt=1000000
+To generate channels from your routing file, use
 
-# Expected Output
-{
-  "funding_txid": "7eeabff3aea0cf4d64e2823841f045e8d3a33cceff237183e3807afe5df2dfa5"
-}
+```bash
+# local
+python smchannels.py --manifest manifest.xml --pvt-key ~/.ssh/id_ed25519 --session mocha --config routing.yaml --disconnect
 ```
 
-This channel should get listed in `lncli-ws pendingchannels`.
-Mine 6 blocks to confirm this channel: `lncli-ws generate 6`.
+Mine 6 blocks to confirm this channel: `./btcctl generate 6`.
 We should be able to see the channel in: `lncli-ws listchannels` now.
 
 ### Sending a payment
+
 First, we need to add an invoice on the recipient, which the sending node will use to trigger payments.
+
 ```bash
 # Cloudlab Node A
 lncli-ws addinvoice --amt=10000
@@ -156,9 +180,66 @@ lncli-ws addinvoice --amt=10000
 ```
 
 And now, on the sending node:
+
 ```bash
 # Cloudlab Node B
 lncli-ws payinvoice <pay_req>
 ```
 
 Upon successful execution, we will see the fund change reflected in the channel info.
+
+## Appendix
+
+### (A) - Manually Opening a Channel
+
+There are 3 steps to this process.
+
+1. We connect the nodes that we want a channel in between.
+2. We create a channel between these nodes which will remain pending till the commited transactions reach a specific depth.
+3. We mine a few blocks so that the said depth is reached and the channel is confirmed.
+
+Initially these will return empty lists:
+
+```bash
+# Cloudlab LND Node
+lncli-ws listpeers
+lncli-ws pendingchannels
+lncli-ws listchannels
+```
+
+Use `getinfo` to get public identity of a node:
+
+```bash
+# On Cloudlab LND Node A
+lncli-ws getinfo
+hostname -I
+```
+
+Then use this address on another node to connect the two:
+
+```bash
+# On Cloudlab LND Node B
+lncli-ws connect <identity_pubkey_of_A>@<ip_of_A>
+```
+
+Now we should see something upon running this:
+
+```bash
+# Cloudlab Node A or B
+lncli-ws listpeers
+```
+
+Open a channel as follows:
+
+```bash
+lncli-ws openchannel --node_key=<address_of_A> --local_amt=1000000
+
+# Expected Output
+{
+  "funding_txid": "7eeabff3aea0cf4d64e2823841f045e8d3a33cceff237183e3807afe5df2dfa5"
+}
+```
+
+This channel should get listed in `lncli-ws pendingchannels`.
+Mine 6 blocks to confirm this channel: `./btcctl generate 6`.
+We should be able to see the channel in: `lncli-ws listchannels` now.

--- a/py/routing.yaml
+++ b/py/routing.yaml
@@ -1,0 +1,28 @@
+Nodes:
+  node1:
+    name: Alice # specifies the name of the node, this is used for logging purposes.
+    address: rm4C4ReiJEe6D1kZkVuzCcEuiUL5oGaBxZ
+    identity_pubkey: 02490ad2248ef5ffee36ba605c41e2dbe89ae24d27b72418d6681a8fe48eb14ca0
+    ip: 10.10.1.2
+  node2:
+    name: Bob
+    address: rWDGjaPKp8EyBKjUHk4KtaV5kpkVfxLg5P
+    identity_pubkey: 02efed49ac16e6c6c6a43317ed56f8581f523f6e9b1d89e769e4018760c5bb289b
+    ip: 10.10.1.3
+  node3:
+    name: Charlie
+    address: rm8pfKFACoxZFpjLdyU3qbi1m3kRgrWhuM
+    identity_pubkey: 038d35671c913fc2fc20539c759d1189eedf88eabdd9b038aeb0bee9d1f7c00f2a
+    ip: 10.10.1.4
+  mining_node:
+    name: node0
+    blocks_to_generate: 6 # specifies the number of blocks to generate after the channel is opened.
+Channels:
+  channel1:
+    firstNode: node1
+    secondNode: node2
+    localAmt: 1000000 # specifies the amount of money that the calling node will commit to the channel.
+  channel2:
+    firstNode: node2
+    secondNode: node3
+    localAmt: 1000000 # specifies the amount of money that the calling node will commit to the channel.

--- a/py/smchannels.py
+++ b/py/smchannels.py
@@ -1,0 +1,132 @@
+import logging
+import paramiko
+import sys
+import os
+import subprocess as sp
+from smparser import parse_manifest
+from smutils import consts, smfiles, get_connections
+from argparse import ArgumentParser
+import yaml
+import time
+
+
+def create_node_targets(filename):
+    with open(filename, 'r') as f:
+        data = yaml.safe_load(f)
+
+    # Access the nodes and the channels data
+    nodes = data.get('Nodes')
+    channels = data.get('Channels')
+    node_dict = {}
+    for channel in channels.values():
+        second_node = channel['secondNode']
+        first_node_name = channel['firstNode']
+        first_node = nodes[first_node_name]
+        local_amt = channel['localAmt']
+        node_dict[second_node] = {
+            'target': first_node_name,
+            'ip': first_node['ip'],
+            'identity_pubkey': first_node['identity_pubkey'],
+            'local_amt': local_amt,
+            'name': first_node['name']
+        }
+        mining_node = nodes['mining_node']['name']
+    return node_dict, mining_node
+
+
+def create_channels(details, pkey, filename='routing.yaml'):
+    node_dict, mining_node = create_node_targets(filename)
+
+    # for each node in the manifest, connect to it and create channels.
+    # to connect to node1 <-> node2 we run the command at node2
+
+    logging.info(
+        "The following nodes are where we are creating the payment channels: {}".format(node_dict.keys()))
+
+    for node, client in zip(details, get_connections(details, pkey)):
+        # only connect to nodes that are in the keys in node_dict, i.e. the second member in the p2p channel
+        if node.name not in node_dict.keys():
+            continue
+
+        # start an interactive shell sesssion, so we can run multiple commands
+        shell = client.invoke_shell()
+        while not shell.recv_ready():
+            time.sleep(0.1)
+        shell.recv(1024).decode()  # Clear the initial login message
+
+        shell.send("source mocha/assets/lightning/lndprofile.sh")
+        shell.send("source mocha/assets/lndconfgen_done.sh")
+
+        logging.info("Connecting to node: {}".format(node.name))
+        shell.send("lncli-ws connect {}@{}".format(
+            node_dict[node.name]['identity_pubkey'], node_dict[node.name]['ip']))
+        output = shell.recv(4096)  # Receive the output from the command
+        # print(output.decode())  # Print the output as a string
+        logging.info(
+            "Confirmed connection between {} <---> {}".format(node.name, node_dict[node.name]['name']))
+
+        shell.send("lncli-ws openchannel --node_key={} --local_amt={}".format(
+            node_dict[node.name]['identity_pubkey'], node_dict[node.name]['local_amt']))
+        output = shell.recv(4096)  # Receive the output from the command
+        # print(output.decode())  # Print the output as a string
+        logging.info(
+            "Payment channel is pending with amount {} committed".format(node_dict[node.name]['local_amt']))
+
+        logging.info(
+            "You will need to mine 6 blocks to confirm the payment channels. Please do so on your mining node: {}.".format(mining_node))
+
+
+def disconnect_channels(details, pkey, filename='routing.yaml'):
+    node_dict, mining_node = create_node_targets(filename)
+    for node, client in zip(details, get_connections(details, pkey)):
+        # only connect to nodes that are in the keys in node_dict, i.e. the second member in the p2p channel
+        if node.name not in node_dict.keys():
+            continue
+
+        # start an interactive shell sesssion, so we can run multiple commands
+        shell = client.invoke_shell()
+        while not shell.recv_ready():
+            time.sleep(0.1)
+        shell.recv(1024).decode()  # Clear the initial login message
+
+        shell.send("source mocha/assets/lightning/lndprofile.sh")
+        shell.send("source mocha/assets/lndconfgen_done.sh")
+
+        shell.send("lncli-ws disconnect {} force".format(
+            node_dict[node.name]['identity_pubkey']))  # using force will disconnect even with an active channel
+        logging.info("Disconnected from node: {}".format(
+            node_dict[node.name]["name"]))
+        shell.recv(4096)  # Receive the output from the command
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+
+    parser = ArgumentParser()
+    parser.add_argument("--manifest", help="manifest for cloudlab")
+    parser.add_argument("--pvt-key", help="private key (file)")
+    parser.add_argument("--session", help="unique session id")
+    parser.add_argument(
+        "--disconnect", help="disconnect all channels you have defined in the yaml file")
+
+    parser.add_argument(
+        "--config", help="yaml file with channels and nodes defined")
+
+    args = parser.parse_args()
+
+    pkey = paramiko.Ed25519Key.from_private_key_file(args.pvt_key)
+
+    details = parse_manifest(args.manifest)
+
+    if args.disconnect:
+        disconnect_channels(details, pkey, args.config)
+        sys.exit(0)
+
+    if args.config:
+        create_channels(details, pkey, args.config)
+
+
+if __name__ == '__main__':
+    main()
+
+# python smchannels.py --manifest manifest.xml --pvt-key ~/.ssh/id_ed25519 --session mocha --config routing.yaml


### PR DESCRIPTION
updated code to allow for automation of opening payment channels. 

two things that you may know how to do easily, but I could not figure out: 
1) when using paramiko shell, I use the client.invoke_shell() and then shell.send to have an interactive shell session. It makes it quite complex to get back the output from the shell and I couldn't figure out how to get the output back in a manner that was beneficial to log, not sure if you have any ideas. 
2) you still need to manually generate 6 blocks on the btcd node to confirm the payment channels. I tried to have the script mine them, but it was not working since I didn't start btcd and so forth, figured it was easier to issue one command rather than create logic for all of that. 

let me know with any notes. 